### PR TITLE
70 fix nextcloud exporter endpoint configuration

### DIFF
--- a/playbooks/roles/align_services/files/nextcloud/docker-compose.yml
+++ b/playbooks/roles/align_services/files/nextcloud/docker-compose.yml
@@ -48,7 +48,7 @@ services:
     image: xperimental/nextcloud-exporter:0.9.1
     restart: unless-stopped
     environment:
-      - 'NEXTCLOUD_SERVER=https://${HOST}'
+      - 'NEXTCLOUD_SERVER=http://nextcloud'
       - 'NEXTCLOUD_AUTH_TOKEN=${NEXTCLOUD_AUTH_TOKEN}'
     labels:
       # diun labels

--- a/playbooks/roles/align_services/files/nextcloud/docker-compose.yml
+++ b/playbooks/roles/align_services/files/nextcloud/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     networks:
       - nextcloud
       - monitoring
-    image: xperimental/nextcloud-exporter:0.9.0
+    image: xperimental/nextcloud-exporter:0.9.1
     restart: unless-stopped
     environment:
       - 'NEXTCLOUD_SERVER=https://${HOST}'


### PR DESCRIPTION
closes #70
- **bumped version**
- **changed nextcloud endpoint to route metrics in docker internal network**
